### PR TITLE
Update ruby-clean-code.md to break rule types into sections

### DIFF
--- a/rules/ruby/ruby-clean-code.md
+++ b/rules/ruby/ruby-clean-code.md
@@ -1,21 +1,24 @@
 ---
 name: Clean Ruby
 ---
+## General Code Standards
 - Write clean and readable ruby code.
 - Follow the Single Responsibility Principle; each method should do one thing.
-- Keep methods under 20 lines and cyclomatic complexity under 7.
 - Use descriptive method names.
-- Break long lines (>100 chars) with line continuations.
-- Use guard clauses and early returns for edge cases.
 - Extract validation, transformation, and complex conditionals into helper methods.
-- Use 2 spaces for indentation.
-- Keep lines under 100 chars.
-- Avoid trailing whitespace.
 - Use snake_case for methods/variables, CamelCase for classes/modules, SCREAMING_SNAKE_CASE for constants.
+- Rescue specific exceptions and use descriptive messages.
+
+## Code Stylistic Requirements
+- Group similar methods.
+- Use early returns.
+- Use guard clauses and early returns for edge cases.
+- Document complex code.
+- Keep methods under 20 lines and cyclomatic complexity under 7.
+- Break long lines (>100 chars) with line continuations.
+- Keep lines under 100 chars.
 - Use single quotes for strings without interpolation.
 - Use double quotes for strings with interpolation.
-- Use early returns.
-- Group similar methods.
-- Document complex code.
-- Rescue specific exceptions and use descriptive messages.
+- Use 2 spaces for indentation.
+- Avoid trailing whitespace.
 - Use your editor to spot and trim trailing whitespace.


### PR DESCRIPTION
Adds a couple sections for the rules to make it easier for humans to parse the ruleset.

The motivation for this is based on the case of rules conflicting with project/editor linters. This separation may make it easier for users to remove any rules they don't want.